### PR TITLE
Embed RSS feed into document head

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,4 +9,5 @@
     <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
     <link href='http://fonts.googleapis.com/css?family=Alegreya:400italic,700italic,900italic,400,700,900' rel='stylesheet' type='text/css'>
+    <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ "/feed.xml" | prepend: site.baseurl }}">
 </head>


### PR DESCRIPTION
This change makes it easier for robots to automatically detect your feed.

I tried to subscribe to your blog, but Reeder wasn't able to find a feed. That's because when I fed it "http://adarowski.github.io/" to subscribe to, it looks for RSS feeds embeded in `<head>`, whereas the site just had a user-clickable feed URL on the page.